### PR TITLE
[codex] Use Argon2id for encrypted exports

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b0253d594ff73f10853b905abbef94b29a6de3e9ea72cf6c4d22d03ca25d9d0d",
+  "originHash" : "c5bce228b3d430b361dc370648dd5b516bb69847859e62234fff059bbe29f385",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
         "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "phc-winner-argon2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/P-H-C/phc-winner-argon2.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "f57e61e19229e23c4445b85494dbf7c07de721cb"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,14 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift", from: "6.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/P-H-C/phc-winner-argon2.git", branch: "master"),
     ],
     targets: [
         .target(
             name: "LokaliteCore",
             dependencies: [
                 .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "argon2", package: "phc-winner-argon2"),
             ],
             path: "Sources/LokaliteCore",
             swiftSettings: [.swiftLanguageMode(.v5)]

--- a/README.md
+++ b/README.md
@@ -155,10 +155,15 @@ Pass `--read-write` to also expose write tools:
 
 ## Roadmap
 
-- Command injection (`lokalite run <cmd>`)
-- Project linking (associate secrets with a directory)
 - Secret references (`lokalite://KEY_NAME` in config files)
 - Cross-platform (Windows, Linux)
+
+Recently completed:
+
+- Environment profiles
+- Command injection (`lokalite run <cmd>`)
+- Project linking (associate secrets with a directory)
+- Agent & MCP integration
 
 ## License
 

--- a/Sources/LokaliteCore/Crypto/VaultCrypto.swift
+++ b/Sources/LokaliteCore/Crypto/VaultCrypto.swift
@@ -1,5 +1,14 @@
 import CryptoKit
 import Foundation
+import argon2
+
+struct ExportKDFParameters {
+    static let current = ExportKDFParameters(iterations: 3, memoryKiB: 64 * 1024, parallelism: 1)
+
+    let iterations: UInt32
+    let memoryKiB: UInt32
+    let parallelism: UInt32
+}
 
 enum VaultCrypto {
     static func generateKey() -> SymmetricKey {
@@ -31,13 +40,45 @@ enum VaultCrypto {
         return value
     }
 
-    // Used for encrypted export: derives a key from passphrase with Argon2id-equivalent (SHA256 stretch for MVP).
-    // TODO: replace with Argon2id before shipping export feature.
-    static func deriveKey(from passphrase: String, salt: Data) -> SymmetricKey {
-        var inputData = Data(passphrase.utf8)
-        inputData.append(salt)
-        let hash = SHA256.hash(data: inputData)
-        return SymmetricKey(data: hash)
+    static func deriveExportKey(
+        from passphrase: String,
+        salt: Data,
+        parameters: ExportKDFParameters = .current
+    ) throws -> SymmetricKey {
+        var passphraseBytes = Array(passphrase.utf8)
+        let saltBytes = Array(salt)
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        let keyLength = keyBytes.count
+
+        let result = keyBytes.withUnsafeMutableBytes { keyBuffer in
+            passphraseBytes.withUnsafeBytes { passphraseBuffer in
+                saltBytes.withUnsafeBytes { saltBuffer in
+                    argon2id_hash_raw(
+                        parameters.iterations,
+                        parameters.memoryKiB,
+                        parameters.parallelism,
+                        passphraseBuffer.baseAddress,
+                        passphraseBytes.count,
+                        saltBuffer.baseAddress,
+                        saltBytes.count,
+                        keyBuffer.baseAddress,
+                        keyLength
+                    )
+                }
+            }
+        }
+
+        passphraseBytes.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            memset_s(baseAddress, buffer.count, 0, buffer.count)
+        }
+
+        guard result == 0 else {
+            let message = argon2_error_message(result).map(String.init(cString:)) ?? "Argon2id error \(result)"
+            throw VaultError.keyDerivationFailed(message)
+        }
+
+        return SymmetricKey(data: keyBytes)
     }
 
     static func generateSalt() -> Data {

--- a/Sources/LokaliteCore/Vault.swift
+++ b/Sources/LokaliteCore/Vault.swift
@@ -277,13 +277,21 @@ public final class Vault {
     }
 
     private func encryptExport(_ data: Data, passphrase: String) throws -> Data {
+        let kdfParameters = ExportKDFParameters.current
         let salt = VaultCrypto.generateSalt()
-        let derivedKey = VaultCrypto.deriveKey(from: passphrase, salt: salt)
+        let derivedKey = try VaultCrypto.deriveExportKey(
+            from: passphrase,
+            salt: salt,
+            parameters: kdfParameters
+        )
         guard let combined = try AES.GCM.seal(data, using: derivedKey).combined else {
             throw VaultError.encryptionFailed
         }
         var envelope = Data()
-        envelope.append(0x01)
+        envelope.append(0x02)
+        envelope.appendUInt32(kdfParameters.iterations)
+        envelope.appendUInt32(kdfParameters.memoryKiB)
+        envelope.appendUInt32(kdfParameters.parallelism)
         envelope.append(salt)
         envelope.append(combined)
         return envelope
@@ -329,5 +337,12 @@ public final class Vault {
 
     private func iso8601() -> String {
         ISO8601DateFormatter().string(from: Date())
+    }
+}
+
+private extension Data {
+    mutating func appendUInt32(_ value: UInt32) {
+        var bigEndian = value.bigEndian
+        Swift.withUnsafeBytes(of: &bigEndian) { append(contentsOf: $0) }
     }
 }

--- a/Sources/LokaliteCore/VaultError.swift
+++ b/Sources/LokaliteCore/VaultError.swift
@@ -14,6 +14,7 @@ public enum VaultError: Error, LocalizedError {
     case noActiveProject
     case databaseError(String)
     case invalidExportPassphrase
+    case keyDerivationFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -43,6 +44,8 @@ public enum VaultError: Error, LocalizedError {
             return "Database error: \(message)"
         case .invalidExportPassphrase:
             return "Invalid passphrase for encrypted export."
+        case .keyDerivationFailed(let message):
+            return "Failed to derive export key: \(message)"
         }
     }
 }

--- a/Sources/lokalite/Commands/RunCommand.swift
+++ b/Sources/lokalite/Commands/RunCommand.swift
@@ -17,10 +17,18 @@ struct RunCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Environment name. Defaults to the active environment.")
     var env: String?
 
+    @Flag(name: [.customShort("h"), .customLong("help")], help: .hidden)
+    var help: Bool = false
+
     @Argument(parsing: .captureForPassthrough, help: "Command and arguments to run.")
     var command: [String]
 
     func run() throws {
+        if help {
+            print(Self.helpMessage())
+            return
+        }
+
         guard !command.isEmpty else {
             print("Error: no command specified.")
             throw ExitCode.failure

--- a/Tests/LokaliteCoreTests/LokaliteCoreTests.swift
+++ b/Tests/LokaliteCoreTests/LokaliteCoreTests.swift
@@ -32,4 +32,26 @@ final class VaultCryptoTests: XCTestCase {
         let restored = VaultCrypto.keyFromData(data)
         XCTAssertEqual(VaultCrypto.keyToData(restored), data)
     }
+
+    func testExportKeyDerivationUsesArgon2idParameters() throws {
+        let salt = Data((0..<32).map(UInt8.init))
+        let params = ExportKDFParameters(iterations: 2, memoryKiB: 8 * 1024, parallelism: 1)
+
+        let first = try VaultCrypto.deriveExportKey(from: "passphrase", salt: salt, parameters: params)
+        let second = try VaultCrypto.deriveExportKey(from: "passphrase", salt: salt, parameters: params)
+
+        XCTAssertEqual(VaultCrypto.keyToData(first), VaultCrypto.keyToData(second))
+        XCTAssertEqual(VaultCrypto.keyToData(first).count, 32)
+    }
+
+    func testExportKeyDerivationChangesWithSalt() throws {
+        let params = ExportKDFParameters(iterations: 2, memoryKiB: 8 * 1024, parallelism: 1)
+        let saltA = Data(repeating: 0xA, count: 32)
+        let saltB = Data(repeating: 0xB, count: 32)
+
+        let first = try VaultCrypto.deriveExportKey(from: "passphrase", salt: saltA, parameters: params)
+        let second = try VaultCrypto.deriveExportKey(from: "passphrase", salt: saltB, parameters: params)
+
+        XCTAssertNotEqual(VaultCrypto.keyToData(first), VaultCrypto.keyToData(second))
+    }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,16 +172,16 @@ lokalite run <command> [args...]  # injects secrets as env vars into subprocess
 
 ### `lokalite run` detail
 
-Lokalite reads a project-local `.lokalite` file (or `--env` flag) listing which secrets to inject:
+Lokalite resolves the current project from `--project`, `LOKALITE_PROJECT`, a linked working directory, or the active project. It resolves the environment from `--env`, `LOKALITE_ENV`, or the project's active environment.
 
-```yaml
-# .lokalite
-inject:
-  - OPENAI_API_KEY
-  - ANTHROPIC_API_KEY
+By default, `lokalite run` injects all secrets from that resolved project/environment. Use `--keys` to limit injection:
+
+```bash
+lokalite run -- npm start
+lokalite run --keys OPENAI_API_KEY,ANTHROPIC_API_KEY -- claude
 ```
 
-Then spawns the subprocess with those secrets in its environment. They never appear in the parent shell.
+The subprocess receives secrets in its environment. They never appear in the parent shell.
 
 ---
 
@@ -223,19 +223,20 @@ Settings (session timeout, launch at login) are accessible via the gear icon in 
 
 ## Export Format
 
-**Encrypted** (default):
+**Encrypted** (default): binary envelope, printed as base64 when no output file is provided.
 
-```json
-{
-  "version": 1,
-  "algorithm": "AES-256-GCM",
-  "kdf": "Argon2id",
-  "salt": "<base64>",
-  "nonce": "<base64>",
-  "ciphertext": "<base64>",
-  "tag": "<base64>"
-}
+Envelope layout:
+
+```text
+0x02
+argon2id_iterations: UInt32BE
+argon2id_memory_kib: UInt32BE
+argon2id_parallelism: UInt32BE
+salt: 32 bytes
+aes_gcm_combined: nonce + ciphertext + tag
 ```
+
+Current Argon2id parameters are 3 iterations, 64 MiB memory, and parallelism 1.
 
 The plaintext being encrypted is a JSON object: `{ "NAME": "value", ... }`.
 
@@ -268,9 +269,6 @@ Also compatible with `.env` format via `--format env`.
 
 ## Roadmap Items (not in MVP)
 
-- MCP server (`lokalite serve`) for agent/Claude Code integration
-- Environment profiles (`ai`, `production`, etc.)
-- Project linking (associate secrets with a directory)
 - Secret references (`lokalite://KEY_NAME` in config files)
 - Cross-platform support (Windows Credential Manager, Linux Secret Service)
 - iCloud Keychain sync (optional, opt-in)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -69,9 +69,11 @@ Full CRUD from the CLI. Commands: `add`, `set`, `delete`, `get`, `copy`, `list`,
 
 ## D8: Agent integration
 
-**Status**: decided `lokalite run` for MVP, MCP server on roadmap
+**Status**: decided `lokalite run` plus MCP server
 
-`lokalite run <command>` injects resolved secrets as env vars into the subprocess. Secrets travel from Keychain → Lokalite memory → child process env. Nothing touches the shell. MCP server is a roadmap item.
+`lokalite run <command>` injects resolved secrets as env vars into the subprocess. Secrets travel from Keychain → Lokalite memory → child process env. Nothing touches the shell.
+
+`lokalite mcp` exposes read-only agent access by default (`get_secret`, `list_secrets`) and write tools only when explicitly started with `--read-write`.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,13 +10,13 @@ Per-project environments (e.g. dev, staging, production). Each secret can carry 
 
 ---
 
-## Command Injection
+## Command Injection ✓
 
 Run applications with secrets automatically injected, without storing credentials in shell profiles or `.env` files.
 
 ```bash
-lokalite run claude
-lokalite run npm start
+lokalite run -- claude
+lokalite run -- npm start
 ```
 
 ---

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -45,7 +45,7 @@ The better model: SQLite stores encrypted secret records, Keychain stores the en
 ## Cryptography
 
 * **Encryption**: AES-256-GCM (authenticated encryption)
-* **Key derivation** (portable/export path): Argon2id
+* **Key derivation** (portable/export path): Argon2id (3 iterations, 64 MiB memory, parallelism 1)
 * **macOS primary path**: app-generated random key stored in Keychain
 
 ---


### PR DESCRIPTION
## Summary

- Replaces the encrypted export SHA256 stretch with Argon2id key derivation using the official PHC Argon2 package.
- Version-tags encrypted export envelopes and records Argon2id parameters before the salt and AES-GCM payload.
- Fixes `lokalite run --help` so help is handled by the CLI instead of being passed through to `/usr/bin/env`.
- Updates roadmap, architecture, security, and decision docs to reflect completed command injection, project linking, MCP, and the new export envelope.

## Validation

- `swift test`
- `swift run lokalite run --help`
- Created a temporary project and verified `lokalite run --project codex-run-check-20260524 --keys LOKALITE_RUN_CHECK -- /usr/bin/printenv LOKALITE_RUN_CHECK` printed `codex-ok`.
- Verified a child command exiting `7` causes `lokalite run` to exit `7`.
- Deleted the temporary validation project.