### PR TITLE
[codex] Keep menu bar app alive after closing manager

### DIFF
--- a/Sources/LokaliteApp/LokaliteApp.swift
+++ b/Sources/LokaliteApp/LokaliteApp.swift
@@ -30,4 +30,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
     }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
 }

--- a/Sources/LokaliteApp/Views/SettingsToolbarConfigurator.swift
+++ b/Sources/LokaliteApp/Views/SettingsToolbarConfigurator.swift
@@ -157,15 +157,15 @@ struct SettingsToolbarConfigurator: NSViewRepresentable {
             item.paletteLabel = "Environment"
             item.toolTip = "Environment"
 
-            let popUp = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 160, height: 32), pullsDown: true)
-            popUp.bezelStyle = .rounded
-            popUp.controlSize = .large
+            let popUp = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 132, height: 28), pullsDown: false)
+            popUp.bezelStyle = .inline
+            popUp.controlSize = .regular
             popUp.font = .systemFont(ofSize: 13, weight: .medium)
             popUp.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                popUp.widthAnchor.constraint(greaterThanOrEqualToConstant: 150),
-                popUp.widthAnchor.constraint(lessThanOrEqualToConstant: 190),
-                popUp.heightAnchor.constraint(equalToConstant: 32)
+                popUp.widthAnchor.constraint(greaterThanOrEqualToConstant: 118),
+                popUp.widthAnchor.constraint(lessThanOrEqualToConstant: 160),
+                popUp.heightAnchor.constraint(equalToConstant: 28)
             ])
 
             item.view = popUp
@@ -189,16 +189,6 @@ struct SettingsToolbarConfigurator: NSViewRepresentable {
             let selectedTitle = vault.selectedEnvironment?.name ?? "Default"
 
             let menu = NSMenu()
-            let titleItem = NSMenuItem(title: selectedTitle, action: nil, keyEquivalent: "")
-            titleItem.attributedTitle = NSAttributedString(
-                string: selectedTitle,
-                attributes: [
-                    .foregroundColor: NSColor.labelColor,
-                    .font: NSFont.systemFont(ofSize: 13, weight: .medium)
-                ]
-            )
-            menu.addItem(titleItem)
-            menu.addItem(.separator())
 
             let defaultItem = menuItem(title: "Default", action: .select(nil))
             defaultItem.state = vault.selectedEnvironment == nil ? .on : .off
@@ -225,7 +215,7 @@ struct SettingsToolbarConfigurator: NSViewRepresentable {
             }
 
             popUp.menu = menu
-            popUp.selectItem(at: 0)
+            popUp.selectItem(withTitle: selectedTitle)
             popUp.isEnabled = vault.selectedProject != nil
         }
 
@@ -251,8 +241,10 @@ struct SettingsToolbarConfigurator: NSViewRepresentable {
                 action: #selector(expandSearch)
             )
             button.bezelStyle = .texturedRounded
-            button.controlSize = .large
+            button.isBordered = false
+            button.controlSize = .regular
             button.imagePosition = .imageOnly
+            button.contentTintColor = .secondaryLabelColor
             button.toolTip = "Search"
             searchToolbarItem.view = button
             searchField = nil


### PR DESCRIPTION
## Summary

- Prevents the app from terminating when the last manager/settings window is closed.
- Keeps Lokalite's menu bar extra alive until the user explicitly quits from the power button or app termination.

## Validation

- \[0/1] Planning build
Building for debugging...
[0/1] Write swift-version--58304C5D6DBC2206.txt
Build of target: 'LokaliteApp' complete! (1.89s)
- \Test Suite 'All tests' started at 2026-05-25 12:29:26.752.
Test Suite 'LokalitePackageTests.xctest' started at 2026-05-25 12:29:26.753.
Test Suite 'VaultCryptoTests' started at 2026-05-25 12:29:26.753.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testDecryptWithWrongKeyFails]' started.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testDecryptWithWrongKeyFails]' passed (0.001 seconds).
Test Case '-[LokaliteCoreTests.VaultCryptoTests testEncryptDecryptRoundtrip]' started.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testEncryptDecryptRoundtrip]' passed (0.000 seconds).
Test Case '-[LokaliteCoreTests.VaultCryptoTests testEncryptProducesUniqueNonces]' started.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testEncryptProducesUniqueNonces]' passed (0.000 seconds).
Test Case '-[LokaliteCoreTests.VaultCryptoTests testExportKeyDerivationChangesWithSalt]' started.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testExportKeyDerivationChangesWithSalt]' passed (0.114 seconds).
Test Case '-[LokaliteCoreTests.VaultCryptoTests testExportKeyDerivationUsesArgon2idParameters]' started.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testExportKeyDerivationUsesArgon2idParameters]' passed (0.171 seconds).
Test Case '-[LokaliteCoreTests.VaultCryptoTests testKeyRoundtrip]' started.
Test Case '-[LokaliteCoreTests.VaultCryptoTests testKeyRoundtrip]' passed (0.000 seconds).
Test Suite 'VaultCryptoTests' passed at 2026-05-25 12:29:27.041.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.287 (0.287) seconds
Test Suite 'LokalitePackageTests.xctest' passed at 2026-05-25 12:29:27.041.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.287 (0.288) seconds
Test Suite 'All tests' passed at 2026-05-25 12:29:27.041.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.287 (0.289) seconds
􀟈  Test run started.
􀄵  Testing Library Version: 1902
􀄵  Target Platform: arm64e-apple-macos14.0
􁁛  Test run with 0 tests in 0 suites passed after 0.001 seconds.