### PR TITLE
Update Homebrew formula and cask to v1.3.0

### DIFF
--- a/Casks/lokalite.rb
+++ b/Casks/lokalite.rb
@@ -1,6 +1,6 @@
 cask "lokalite" do
-  version "1.2.4"
-  sha256 "317db09db247f805f16d311281fd521c45761469b71b08a5ebac4782cdb9ddff"
+  version "1.3.0"
+  sha256 "590c0db0804530290b8cff4be51a8dea8df73acedd5beb2154980cbfb178338e"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.2.4.tar.gz"
-  sha256 "4a0e67382a19021697a742f67e3fb8f798ce3d5bb5a8cd469b6806e761bd8f0c"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.3.0.tar.gz"
+  sha256 "78936973d2664462cad3035c4c5f31091eee8ffd2a7d1e200fe04e407be02a54"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Update Homebrew formula and cask to v1.3.0.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite.rb`

The branch was created automatically from the release tag and is ready to merge into `main`.