### PR TITLE
Update Homebrew formula and cask to v1.4.0

### DIFF
--- a/Casks/lokalite.rb
+++ b/Casks/lokalite.rb
@@ -1,6 +1,6 @@
 cask "lokalite" do
-  version "1.2.4"
-  sha256 "317db09db247f805f16d311281fd521c45761469b71b08a5ebac4782cdb9ddff"
+  version "1.4.0"
+  sha256 "769aacf4b0ec9b02103248a0e38b8598603fbfe69f9c177c7802d54da7e034f5"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.2.4.tar.gz"
-  sha256 "4a0e67382a19021697a742f67e3fb8f798ce3d5bb5a8cd469b6806e761bd8f0c"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.4.0.tar.gz"
+  sha256 "774a1f61d20ce8ff151bd2625e6d7420b6ce2a0984bbb5b5bd8fede0eab183bc"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Update Homebrew formula and cask to v1.4.0.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite.rb`

The branch was created automatically from the release tag and is ready to merge into `main`.