### PR TITLE
Update Homebrew formula and cask to v1.5.0

### DIFF
--- a/Casks/lokalite.rb
+++ b/Casks/lokalite.rb
@@ -1,6 +1,6 @@
 cask "lokalite" do
-  version "1.2.4"
-  sha256 "317db09db247f805f16d311281fd521c45761469b71b08a5ebac4782cdb9ddff"
+  version "1.5.0"
+  sha256 "19c5c2c951827dfbd81154099149d5ec784e9698048cf69e6e14d2fe91d76c5e"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.2.4.tar.gz"
-  sha256 "4a0e67382a19021697a742f67e3fb8f798ce3d5bb5a8cd469b6806e761bd8f0c"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.5.0.tar.gz"
+  sha256 "98791c7022143fca8be778b9bafd3ecb0657d84bb0820038fa31a94741223460"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Update Homebrew formula and cask to v1.5.0.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite.rb`

The branch was created automatically from the release tag (PR opened manually because HOMEBREW_PR_TOKEN is not configured).