### PR TITLE
Update Homebrew formula and cask to v1.6.0

### DIFF
--- a/Casks/lokalite.rb
+++ b/Casks/lokalite.rb
@@ -1,6 +1,6 @@
 cask "lokalite" do
-  version "1.5.0"
-  sha256 "19c5c2c951827dfbd81154099149d5ec784e9698048cf69e6e14d2fe91d76c5e"
+  version "1.6.0"
+  sha256 "1f9f646476a1fdcabb0202b4e09da6741728fcbfd4a2b7b03e9253f1e8b5d6db"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.5.0.tar.gz"
-  sha256 "98791c7022143fca8be778b9bafd3ecb0657d84bb0820038fa31a94741223460"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.6.0.tar.gz"
+  sha256 "5960f9e8e97293599c52b619b86781809e77bb418b2590d24fa498f12190ee12"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Bumps the Homebrew formula (CLI source tarball) and cask (app DMG) to v1.6.0.

v1.6.0 adds `lokalite list --search`, `lokalite log`, `lokalite backup`/`restore`, and MCP working-directory project auto-resolution. See the [release](https://github.com/RubenGlez/lokalite/releases/tag/v1.6.0).

Auto-generated by the release workflow; opened manually because `HOMEBREW_PR_TOKEN` is not configured. Merge after the `check` status passes so `brew` users get v1.6.0.

https://claude.ai/code/session_01U1teWg8WSSArSVobWESLwG