### PR TITLE
Update Homebrew formula and cask to v1.7.0

### DIFF
--- a/Casks/lokalite.rb
+++ b/Casks/lokalite.rb
@@ -1,6 +1,6 @@
 cask "lokalite" do
-  version "1.6.0"
-  sha256 "1f9f646476a1fdcabb0202b4e09da6741728fcbfd4a2b7b03e9253f1e8b5d6db"
+  version "1.7.0"
+  sha256 "8c78f032724c8f20af48af071dcd92f55fbb6290cdbbd19ab122bbae37d6c92b"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.6.0.tar.gz"
-  sha256 "5960f9e8e97293599c52b619b86781809e77bb418b2590d24fa498f12190ee12"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.7.0.tar.gz"
+  sha256 "8242e2302987d75ce36460517d7a14064be9b782b2bb45ea9360c04faca01851"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Bumps the Homebrew formula (CLI source tarball) and cask (app DMG) to v1.7.0.

v1.7.0 adds `lokalite init --from-env` (create a project from a `.env`) and the app's guided `.env` import. See the [release](https://github.com/RubenGlez/lokalite/releases/tag/v1.7.0).

Auto-generated by the release workflow; opened manually because `HOMEBREW_PR_TOKEN` is not configured. Merge after the `check` status passes so `brew` users get v1.7.0.

https://claude.ai/code/session_01U1teWg8WSSArSVobWESLwG