### PR TITLE
Update Homebrew formula and cask to v1.8.0

### DIFF
--- a/Casks/lokalite.rb
+++ b/Casks/lokalite.rb
@@ -1,6 +1,6 @@
 cask "lokalite" do
-  version "1.7.1"
-  sha256 "3b71fc47095119a6adbab5ffc33195d0ebd8b21a85d00284a542517b4b8b33c3"
+  version "1.8.0"
+  sha256 "6a22bf50e31a247b8dbc6516ba72f9232100a6de50aeff8082afe8b3a09b4bae"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.7.1.tar.gz"
-  sha256 "e5f66c4d3820087591deee586cd8786c670afe829259b8905188732d9f376f0b"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.8.0.tar.gz"
+  sha256 "a077001407bac43cfa656a2ff257eac9ce881fa37d47a3474b518e2370068e4c"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Automated formula/cask bump for the v1.8.0 release.

https://claude.ai/code/session_015z1koWmeJKFQFeg8UaMj1S