### PR TITLE
Homebrew: update formula and cask to v2.0.0

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "1.8.2"
-  sha256 "0fc53b0952fd0054794c4f8548bde7a428878002356fe0c013e14bf3979d4443"
+  version "2.0.0"
+  sha256 "535742baa40e9b63db414505a358ab415cf00fae9d68211c0d284b0003712a82"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v1.8.2.tar.gz"
-  sha256 "47f7edb6e4643919bc9bfdf783e0da824eca2747bbad40c39030f1c422a03335"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "82d87cd779478040f573770831a7fdb69c75f2a04efcbad708e330f20be6db5b"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Updates `Formula/lokalite.rb` and `Casks/lokalite-app.rb` to v2.0.0 (auto-generated by the release workflow).

https://claude.ai/code/session_01NRqf9QhXVcfBjAgYPcEBFY