### PR TITLE
Homebrew: update formula and cask to v2.0.1

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.0.0"
-  sha256 "535742baa40e9b63db414505a358ab415cf00fae9d68211c0d284b0003712a82"
+  version "2.0.1"
+  sha256 "72d1757e81c6fd2907e1bdc6e17f8e424ef6c92ad66df192298605f6d97f0f91"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.0.0.tar.gz"
-  sha256 "82d87cd779478040f573770831a7fdb69c75f2a04efcbad708e330f20be6db5b"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.0.1.tar.gz"
+  sha256 "356a135d28cc9c5dd9919990bba418a5f90e0dab90981f7979c897c428a21117"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Updates `Formula/lokalite.rb` and `Casks/lokalite-app.rb` to v2.0.1 (auto-generated by the release workflow).

https://claude.ai/code/session_01NRqf9QhXVcfBjAgYPcEBFY