### PR TITLE
Homebrew: update formula and cask to v2.1.0

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.0.1"
-  sha256 "72d1757e81c6fd2907e1bdc6e17f8e424ef6c92ad66df192298605f6d97f0f91"
+  version "2.1.0"
+  sha256 "428e3bdc066e7e24188917d16c715015518dbcb4c173e8ac8316e141668fe96f"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.0.1.tar.gz"
-  sha256 "356a135d28cc9c5dd9919990bba418a5f90e0dab90981f7979c897c428a21117"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "67c67ccf5bb058f36bd20f125d9918439c660e605eec4e17eb4b44cbeed3f276"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Updates `Formula/lokalite.rb` (CLI) and `Casks/lokalite-app.rb` (app) to v2.1.0, generated by the release workflow from the published GitHub Release artifacts and `SHA256SUMS`.

Release: agent governance (requiresApproval consent-on-read tier, agent-attributed access dashboard), per-environment agent workflow, and the Cmd+Tab manager window.

https://claude.ai/code/session_01ANQpowggWseYMG6ZVpPMdN