### PR TITLE
Update Homebrew formula and cask to v2.2.0

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.1.0"
-  sha256 "428e3bdc066e7e24188917d16c715015518dbcb4c173e8ac8316e141668fe96f"
+  version "2.2.0"
+  sha256 "b6b22d7074a9e096dcdad7cd7633b94927424d67534fd702071e669e89f3265c"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.1.0.tar.gz"
-  sha256 "67c67ccf5bb058f36bd20f125d9918439c660e605eec4e17eb4b44cbeed3f276"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.2.0.tar.gz"
+  sha256 "c331e043371f767790ac86f4722af39e9ee26ec83d272896df7f270a48368d94"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Automated formula/cask bump for the v2.2.0 release (CLI + app). Merges once `build-and-test` is green.

https://claude.ai/code/session_01SgDxeffep666d4BrKznrcQ