### PR TITLE
Update Homebrew formula and cask to v2.2.1

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.2.0"
-  sha256 "b6b22d7074a9e096dcdad7cd7633b94927424d67534fd702071e669e89f3265c"
+  version "2.2.1"
+  sha256 "5e8a0804267080f3c67d69fb7562e0a2a8f12204400f8034aff5604555128c28"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.2.0.tar.gz"
-  sha256 "c331e043371f767790ac86f4722af39e9ee26ec83d272896df7f270a48368d94"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.2.1.tar.gz"
+  sha256 "2a5c6a5dfe18ee9dfcd75d49dbd394a558a12a0d114efc5fac9d71b1021f7381"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 


### PR DESCRIPTION
Automated formula/cask bump for v2.2.1 (first signed + notarized release). Merges once build-and-test is green.

https://claude.ai/code/session_01SgDxeffep666d4BrKznrcQ