### PR TITLE
Sparkle in-app auto-updates + automated Homebrew/appcast release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,11 +137,34 @@ jobs:
             <true/>
             <key>NSHighResolutionCapable</key>
             <true/>
+            <key>SUFeedURL</key>
+            <string>https://raw.githubusercontent.com/RubenGlez/lokalite/main/appcast.xml</string>
+            <key>SUPublicEDKey</key>
+            <string>C414ty+O4JN3PkkOQ8tMQeuwxE6Y+vSuCbuG2GOh/lA=</string>
           </dict>
           </plist>
           EOF
 
           printf 'APPL????' > LokaliteApp.app/Contents/PkgInfo
+
+          # Embed Sparkle so the app can self-update (unconditional: without the
+          # framework dyld can't resolve @rpath/Sparkle.framework and the app
+          # would crash on launch). swift build populates .build/artifacts; the
+          # xcframework slice is universal (arm64 + x86_64).
+          SPARKLE_FW="$(find .dd/Build/Products -maxdepth 2 -name Sparkle.framework -type d 2>/dev/null | head -1)"
+          if [ -z "${SPARKLE_FW}" ]; then
+            SPARKLE_FW="$(find .build/artifacts -path '*macos-arm64_x86_64/Sparkle.framework' -type d 2>/dev/null | head -1)"
+          fi
+          if [ -z "${SPARKLE_FW}" ]; then
+            echo "Sparkle.framework not found" >&2
+            exit 1
+          fi
+          mkdir -p LokaliteApp.app/Contents/Frameworks
+          ditto "${SPARKLE_FW}" LokaliteApp.app/Contents/Frameworks/Sparkle.framework
+          # The executable's LC_RPATH points at build dirs / @loader_path; add the
+          # bundle's Frameworks dir so @rpath/Sparkle.framework resolves at runtime.
+          install_name_tool -add_rpath "@executable_path/../Frameworks" \
+            LokaliteApp.app/Contents/MacOS/LokaliteApp 2>/dev/null || true
 
       - name: Sign app bundle (Developer ID)
         if: env.SIGNING == '1'
@@ -153,6 +176,20 @@ jobs:
             codesign --force --options runtime --timestamp \
               --sign "${APP_IDENTITY}" "${bundle}"
           done
+          # Sparkle's nested helpers must be signed before the framework, which
+          # must be signed before the app (do not use --deep). Downloader.xpc
+          # keeps its own sandbox entitlements.
+          SPARKLE_V="LokaliteApp.app/Contents/Frameworks/Sparkle.framework/Versions/B"
+          codesign --force --options runtime --timestamp \
+            --sign "${APP_IDENTITY}" "${SPARKLE_V}/XPCServices/Installer.xpc"
+          codesign --force --options runtime --timestamp --preserve-metadata=entitlements \
+            --sign "${APP_IDENTITY}" "${SPARKLE_V}/XPCServices/Downloader.xpc"
+          codesign --force --options runtime --timestamp \
+            --sign "${APP_IDENTITY}" "${SPARKLE_V}/Autoupdate"
+          codesign --force --options runtime --timestamp \
+            --sign "${APP_IDENTITY}" "${SPARKLE_V}/Updater.app"
+          codesign --force --options runtime --timestamp \
+            --sign "${APP_IDENTITY}" "LokaliteApp.app/Contents/Frameworks/Sparkle.framework"
           codesign --force --options runtime --timestamp \
             --entitlements LokaliteApp.entitlements \
             --sign "${APP_IDENTITY}" LokaliteApp.app/Contents/MacOS/LokaliteApp
@@ -268,6 +305,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HOMEBREW_PR_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
           VERSION="${GITHUB_REF_NAME}"
           BRANCH="homebrew/${VERSION}"
@@ -303,11 +341,48 @@ jobs:
           sed -i '' "s|version \".*\"|version \"${SHORT_VERSION}\"|" Casks/lokalite-app.rb
           sed -i '' "s|sha256 \"[a-f0-9]*\"|sha256 \"${CASK_SHA}\"|" Casks/lokalite-app.rb
 
+          # Sign the DMG and prepend a Sparkle appcast item so notarized users get
+          # in-app auto-updates. The appcast on main is served verbatim over
+          # raw.githubusercontent (SUFeedURL), so it updates when this PR merges —
+          # same cadence as the cask. Skipped when the key is absent so releases
+          # never hard-fail before the secret is configured.
+          if [ -n "${SPARKLE_ED_PRIVATE_KEY}" ]; then
+            SIGN_OUTPUT="$(printf '%s' "${SPARKLE_ED_PRIVATE_KEY}" | .build/artifacts/sparkle/Sparkle/bin/sign_update --ed-key-file - "Lokalite-${VERSION}.dmg")"
+            ED_SIG="$(printf '%s' "${SIGN_OUTPUT}" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
+            ED_LEN="$(printf '%s' "${SIGN_OUTPUT}" | sed -n 's/.*length="\([^"]*\)".*/\1/p')"
+            if [ -z "${ED_SIG}" ] || [ -z "${ED_LEN}" ]; then
+              echo "Failed to derive appcast signature from sign_update output: ${SIGN_OUTPUT}" >&2
+              exit 1
+            fi
+            PUBDATE="$(date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+            cat > /tmp/appcast-item.xml << ITEM
+          <item>
+            <title>Lokalite ${SHORT_VERSION}</title>
+            <link>https://github.com/RubenGlez/lokalite/releases/tag/${VERSION}</link>
+            <sparkle:version>${SHORT_VERSION}</sparkle:version>
+            <sparkle:shortVersionString>${SHORT_VERSION}</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <pubDate>${PUBDATE}</pubDate>
+            <enclosure url="${DMG_URL}" sparkle:edSignature="${ED_SIG}" length="${ED_LEN}" type="application/octet-stream" />
+          </item>
+          ITEM
+            awk '/<!-- BEGIN ITEMS -->/{print; while((getline line < "/tmp/appcast-item.xml") > 0) print line; next} {print}' appcast.xml > appcast.xml.new
+            mv appcast.xml.new appcast.xml
+            APPCAST_CHANGED=1
+          else
+            echo "SPARKLE_ED_PRIVATE_KEY not set; skipping appcast update."
+          fi
+
           git config user.email "action@github.com"
           git config user.name "GitHub Actions"
           git checkout -B "${BRANCH}"
           git add Formula/lokalite.rb Casks/lokalite-app.rb
-          git commit -m "Update Homebrew formula and cask to ${VERSION}"
+          COMMIT_MSG="Update Homebrew formula and cask to ${VERSION}"
+          if [ "${APPCAST_CHANGED:-}" = "1" ]; then
+            git add appcast.xml
+            COMMIT_MSG="Update Homebrew formula, cask, and Sparkle appcast to ${VERSION}"
+          fi
+          git commit -m "${COMMIT_MSG}"
           git push -u origin "${BRANCH}"
 
           printf '%s\n' \
@@ -316,6 +391,7 @@ jobs:
             "This release workflow refreshes:" \
             "- \`Formula/lokalite.rb\`" \
             "- \`Casks/lokalite-app.rb\`" \
+            "- \`appcast.xml\` (Sparkle in-app update feed)" \
             "" \
             "The branch was created automatically from the release tag and is ready to merge into \`main\`." \
             > /tmp/homebrew-pr-body.md
@@ -327,12 +403,18 @@ jobs:
                 --repo RubenGlez/lokalite \
                 --base main \
                 --head "${BRANCH}" \
-                --draft \
-                --title "Update Homebrew formula and cask to ${VERSION}" \
+                --title "${COMMIT_MSG}" \
                 --body-file /tmp/homebrew-pr-body.md)
             fi
 
             echo "Homebrew PR: ${PR_URL}"
+
+            # Merge automatically once the branch's build-and-test status passes,
+            # so a release is fully hands-off. Best-effort: if repo auto-merge is
+            # disabled the PR just stays open for a manual merge.
+            if ! GH_TOKEN="${HOMEBREW_PR_TOKEN}" gh pr merge "${PR_URL}" --auto --squash; then
+              echo "Could not enable auto-merge; merge the PR manually once checks pass."
+            fi
           else
             echo "HOMEBREW_PR_TOKEN is not configured; skipping PR creation."
             echo "Open the branch manually if you want an automatic Homebrew PR:"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,15 @@
 2. Prepend the new entry to `CHANGELOG.md` and commit it (the release script refuses a dirty tree). The link-reference list at the bottom is stale; recent releases don't add to it.
 3. Push the release commits to `main` (`git push origin main`). The release script only pushes the tag, not the branch — and its safety check only catches being *behind* `origin/main`, not *ahead* — so unpushed local commits would otherwise live only under the tag.
 4. `scripts/release.sh [patch|minor|major]` — computes the next tag from the latest `v*` tag, tags, and pushes the tag.
-5. The tag triggers `.github/workflows/release.yml`: builds the app with xcodebuild, creates DMG/PKG/ZIP + `SHA256SUMS`, publishes the GitHub Release, and pushes a `homebrew/vX.Y.Z` branch updating `Formula/lokalite.rb` and `Casks/lokalite-app.rb`.
-6. `HOMEBREW_PR_TOKEN` is not configured in repo secrets, so the workflow does NOT open the Homebrew PR — create it manually from the `homebrew/vX.Y.Z` branch, wait for the `build-and-test` status, and merge it. Until that PR merges, `brew` users keep getting the previous version.
+5. The tag triggers `.github/workflows/release.yml`: builds the app with xcodebuild, embeds + signs Sparkle.framework, creates DMG/PKG/ZIP + `SHA256SUMS`, publishes the GitHub Release, and pushes a `homebrew/vX.Y.Z` branch updating `Formula/lokalite.rb`, `Casks/lokalite-app.rb`, and `appcast.xml` (the signed Sparkle item for this version, prepended after the `<!-- BEGIN ITEMS -->` marker).
+6. Homebrew + appcast merge together in one PR off the `homebrew/vX.Y.Z` branch. When `HOMEBREW_PR_TOKEN` is set, the workflow opens that PR and enables auto-merge (squash), so it merges itself once the branch's `build-and-test` status passes — no manual step. If the token is unset, the workflow only pushes the branch; open and merge the PR manually. Until it merges, `brew` users get the previous version **and** the Sparkle feed (served from `appcast.xml` on `main` via raw.githubusercontent) still advertises the previous version.
 7. Record the release in the roadmap (Shipped section, version + date).
+
+### In-app updates (Sparkle)
+
+The app self-updates via [Sparkle](https://sparkle-project.org): a menu-bar "Check for Updates…" item (right-click the status icon, or Settings → Updates) plus automatic background checks after the user opts in on first launch. The updater only runs in signed release builds — `SoftwareUpdater` returns an inert controller in dev builds (no `SUFeedURL`, no embedded framework), so `swift run`/Xcode debugging never hits the release feed.
+
+`SUFeedURL` points at `appcast.xml` on `main` served over raw.githubusercontent, so the feed advances only when the release PR (step 6) merges — same cadence as the cask. `SUPublicEDKey` is hardcoded in the Info.plist the workflow generates; the matching EdDSA private key signs each DMG via Sparkle's `sign_update` (key from `.build/artifacts` after `swift build`). The key pair is the account-wide Sparkle signing key (`generate_keys`, stored in the login Keychain); if the appcast ever needs re-signing locally, `sign_update` reads that key automatically.
 
 ### Signing & notarization
 
@@ -17,6 +23,8 @@ The release workflow signs with Developer ID + hardened runtime and notarizes wh
 - `MACOS_SIGN_P12` / `MACOS_SIGN_PASSWORD` — Developer ID **Application** cert+key as a base64 `.p12`, and its export password. Signs the app bundle, its nested `.bundle` resources, and the CLI binary.
 - `MACOS_NOTARY_KEY` / `MACOS_NOTARY_KEY_ID` / `MACOS_NOTARY_ISSUER_ID` — App Store Connect API key (base64 `.p8`, Key ID, Issuer ID) for `notarytool`. Notarization runs only when both the app cert and this key are present.
 - `MACOS_SIGN_INSTALLER_P12` / `MACOS_SIGN_INSTALLER_PASSWORD` — Developer ID **Installer** cert for signing the `.pkg`. Not currently set (no Installer cert exists), so the CLI pkg ships unsigned; everything else still signs and notarizes.
+- `SPARKLE_ED_PRIVATE_KEY` — base64 EdDSA private seed (from `generate_keys -x`) that signs each DMG for the Sparkle appcast. Its public half is the hardcoded `SUPublicEDKey` in `release.yml`. If unset, the release still ships but the appcast item is skipped (no auto-update for that version). **Not** account-wide — it is Lokalite's own Sparkle key; keep a copy in the vault's `Global` project.
+- `HOMEBREW_PR_TOKEN` — PAT (repo scope) used to open and auto-merge the Homebrew/appcast PR. If unset, the workflow only pushes the `homebrew/vX.Y.Z` branch.
 
 The workflow maps these to descriptive internal job-env names; the signing identity itself is discovered from the imported cert at build time (no identity name is hardcoded). `LokaliteApp.entitlements` is intentionally empty — the app is not sandboxed (Carbon hotkey + Unix socket) and needs no special entitlement under the hardened runtime. Canonical copies of these credentials live in the `lokalite` vault's `Global` project; GitHub Actions secrets are the CI mirror.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e6afb7edc3c1e6fcba23176278e34510709dcf482a5fb50addeb94c935dab52f",
+  "originHash" : "d38cc95b12041e8a9e39a6c956c842bc8ad2105628cdbaa6b69991725497bae6",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -16,6 +16,15 @@
       "location" : "https://github.com/P-H-C/phc-winner-argon2.git",
       "state" : {
         "revision" : "f57e61e19229e23c4445b85494dbf7c07de721cb"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/P-H-C/phc-winner-argon2.git", revision: "f57e61e19229e23c4445b85494dbf7c07de721cb"),
         .package(url: "https://github.com/xnth97/SymbolPicker.git", .upToNextMajor(from: "1.6.0")),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
     ],
     targets: [
         .target(
@@ -39,6 +40,7 @@ let package = Package(
             dependencies: [
                 "LokaliteCore",
                 .product(name: "SymbolPicker", package: "SymbolPicker"),
+                .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/LokaliteApp",
             resources: [

--- a/Sources/LokaliteApp/LokaliteApp.swift
+++ b/Sources/LokaliteApp/LokaliteApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Sparkle
 import LokaliteCore
 
 @main
@@ -22,6 +23,7 @@ struct LokaliteApp: App {
         Window("Lokalite", id: "settings") {
             SettingsView()
                 .environment(appDelegate.vault)
+                .environment(appDelegate.softwareUpdater)
                 .frame(minWidth: 980, minHeight: 620)
         }
         .defaultSize(width: 1180, height: 720)
@@ -32,6 +34,7 @@ struct LokaliteApp: App {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let vault = VaultViewModel()
+    let softwareUpdater = SoftwareUpdater()
     let hotkeyManager = GlobalHotkeyManager()
     private var windowEventMonitor: Any?
     private var windowKeyObserver: NSObjectProtocol?
@@ -176,6 +179,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let contentView = window.contentView else { return event }
 
             let menu = NSMenu()
+            if let updater = self.softwareUpdater.controller {
+                let checkForUpdates = NSMenuItem(
+                    title: "Check for Updates…",
+                    action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+                    keyEquivalent: "")
+                checkForUpdates.target = updater
+                menu.addItem(checkForUpdates)
+                menu.addItem(.separator())
+            }
             menu.addItem(NSMenuItem(title: "Quit Lokalite",
                                     action: #selector(NSApplication.terminate(_:)),
                                     keyEquivalent: "q"))

--- a/Sources/LokaliteApp/SoftwareUpdater.swift
+++ b/Sources/LokaliteApp/SoftwareUpdater.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Sparkle
+import LokaliteCore
+
+/// Wraps Sparkle's updater so the menu-bar app can offer "Check for Updates…".
+///
+/// Sparkle needs a Developer ID-signed, notarized bundle with an embedded
+/// `Sparkle.framework` and an `SUFeedURL` in Info.plist to work; only release
+/// builds produce those. Development builds run from `swift build`/Xcode without
+/// a feed URL, so the updater stays inert there and the UI hides its controls.
+@Observable
+@MainActor
+final class SoftwareUpdater {
+    @ObservationIgnored let controller: SPUStandardUpdaterController?
+
+    init() {
+        if VaultConfiguration.isDevelopmentBuild {
+            controller = nil
+        } else {
+            controller = SPUStandardUpdaterController(
+                startingUpdater: true,
+                updaterDelegate: nil,
+                userDriverDelegate: nil
+            )
+        }
+    }
+
+    var isAvailable: Bool { controller != nil }
+
+    func checkForUpdates() {
+        controller?.checkForUpdates(nil)
+    }
+}

--- a/Sources/LokaliteApp/Views/SettingsSecretDialogs.swift
+++ b/Sources/LokaliteApp/Views/SettingsSecretDialogs.swift
@@ -5,9 +5,14 @@ import LokaliteCore
 
 struct AppSettingsView: View {
     @Environment(VaultViewModel.self) private var vault
+    @Environment(SoftwareUpdater.self) private var softwareUpdater
     @Environment(\.dismiss) private var dismiss
     @State private var sessionTimeoutSeconds: Double = 300
     @State private var clipboardClearSeconds: Double = 30
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+    }
 
     var body: some View {
         NavigationStack {
@@ -56,6 +61,23 @@ struct AppSettingsView: View {
                         vault.lock()
                     } label: {
                         Label("Lock Now", systemImage: "lock")
+                    }
+                }
+
+                Section("Updates") {
+                    LabeledContent("Version", value: appVersion)
+
+                    if softwareUpdater.isAvailable {
+                        Button {
+                            softwareUpdater.checkForUpdates()
+                            dismiss()
+                        } label: {
+                            Label("Check for Updates…", systemImage: "arrow.down.circle")
+                        }
+                    } else {
+                        Text("Updates are available in signed release builds.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }

--- a/Sources/LokaliteApp/Views/SettingsView.swift
+++ b/Sources/LokaliteApp/Views/SettingsView.swift
@@ -7,6 +7,7 @@ import SymbolPicker
 
 struct SettingsView: View {
     @Environment(VaultViewModel.self) private var vault
+    @Environment(SoftwareUpdater.self) private var softwareUpdater
     @State private var selectedSecret: Secret?
     @State private var selectedTab = "Overview"
     @State private var projectSearchText = ""
@@ -121,7 +122,7 @@ struct SettingsView: View {
             case .addSecret:
                 AddSecretView().environment(vault)
             case .appSettings:
-                AppSettingsView().environment(vault)
+                AppSettingsView().environment(vault).environment(softwareUpdater)
             case .editSecret(let secret):
                 EditSecretView(secret: secret).environment(vault)
             case .moveSecret(let secret):

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Lokalite</title>
+    <link>https://raw.githubusercontent.com/RubenGlez/lokalite/main/appcast.xml</link>
+    <description>Lokalite update feed</description>
+    <language>en</language>
+    <!-- BEGIN ITEMS -->
+  </channel>
+</rss>


### PR DESCRIPTION
Adds [Sparkle](https://sparkle-project.org) for signed, notarized in-app updates, and automates the Homebrew/appcast release PR.

## In-app updates (Sparkle 2.9)
- `SoftwareUpdater` wraps `SPUStandardUpdaterController`; **inert in dev builds** (no `SUFeedURL` / embedded framework), so `swift run` never hits the release feed.
- "Check for Updates…" in the status-icon right-click menu and **Settings → Updates** (version + button); automatic background checks after a first-launch opt-in.
- `release.yml` embeds + inside-out signs `Sparkle.framework`, injects `SUFeedURL` + `SUPublicEDKey`, signs each DMG with `sign_update`, and prepends a signed item to `appcast.xml`.

## Release automation
- Folds the appcast into the existing `homebrew/vX.Y.Z` branch so one PR updates formula + cask + feed.
- When `HOMEBREW_PR_TOKEN` is set, the workflow opens that PR and enables auto-merge (squash) so it merges once `build-and-test` passes.

## Distribution notes
- Appcast is served from `appcast.xml` on `main` over raw.githubusercontent (`SUFeedURL`), so the feed advances when a release PR merges — same cadence as the cask.
- Auto-update only works *from* a Sparkle-equipped build; the first such release still installs via brew/DMG.

Verified: `swift build` clean, 149/149 tests pass, app launches with Sparkle linked (updater inert in dev), `sign_update`→verify round-trips, appcast splice produces valid XML.

https://claude.ai/code/session_01Y1eMoWweDvWtVg7Ecd8g99