### PR TITLE
Update Homebrew formula, cask, and Sparkle appcast to v2.3.0

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.2.1"
-  sha256 "5e8a0804267080f3c67d69fb7562e0a2a8f12204400f8034aff5604555128c28"
+  version "2.3.0"
+  sha256 "9069686679033032bbdd17fa0a15d03d7ff5698e8bec10625537c1659d3af9c3"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.2.1.tar.gz"
-  sha256 "2a5c6a5dfe18ee9dfcd75d49dbd394a558a12a0d114efc5fac9d71b1021f7381"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.3.0.tar.gz"
+  sha256 "32f2ff610becb864bdfb3c0df7a112e6b6c62379c336f8b17f6b9c6a54a5bedf"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,5 +6,14 @@
     <description>Lokalite update feed</description>
     <language>en</language>
     <!-- BEGIN ITEMS -->
+<item>
+  <title>Lokalite 2.3.0</title>
+  <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.3.0</link>
+  <sparkle:version>2.3.0</sparkle:version>
+  <sparkle:shortVersionString>2.3.0</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+  <pubDate>Fri, 03 Jul 2026 09:15:44 +0000</pubDate>
+  <enclosure url="https://github.com/RubenGlez/lokalite/releases/download/v2.3.0/Lokalite-v2.3.0.dmg" sparkle:edSignature="KFuzvmFVUdSdjkTa4khFb/LeiCKo631qjca0+vsKGGb9C2rn106x+4y5FIMT6SSU/VKpYWO19CzRIDL4fO45AQ==" length="6932340" type="application/octet-stream" />
+</item>
   </channel>
 </rss>


### PR DESCRIPTION
Update Homebrew formula and cask to v2.3.0.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite-app.rb`
- `appcast.xml` (Sparkle in-app update feed)

The branch was created automatically from the release tag and is ready to merge into `main`.
