### PR TITLE
Update Homebrew formula, cask, and Sparkle appcast to v2.4.0

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.3.0"
-  sha256 "9069686679033032bbdd17fa0a15d03d7ff5698e8bec10625537c1659d3af9c3"
+  version "2.4.0"
+  sha256 "238f22a543f6c932c502eea41ce370daa26a1cddd00863446782d7e23fdce6b9"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.3.0.tar.gz"
-  sha256 "32f2ff610becb864bdfb3c0df7a112e6b6c62379c336f8b17f6b9c6a54a5bedf"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.4.0.tar.gz"
+  sha256 "843c11401412ff55f34fc1efc4306a2685d2a5fde6c29776dddc4b3dba82acc1"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -7,6 +7,15 @@
     <language>en</language>
     <!-- BEGIN ITEMS -->
 <item>
+  <title>Lokalite 2.4.0</title>
+  <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.4.0</link>
+  <sparkle:version>2.4.0</sparkle:version>
+  <sparkle:shortVersionString>2.4.0</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+  <pubDate>Fri, 03 Jul 2026 18:30:47 +0000</pubDate>
+  <enclosure url="https://github.com/RubenGlez/lokalite/releases/download/v2.4.0/Lokalite-v2.4.0.dmg" sparkle:edSignature="cAoU7YoVdDVaJhSq1PlXuTedxRPEFWOruVgJeMpWF/H26d6s9Go8Qg1NoAOulZ7fyp/tt1Vj09lRUBRkTs6rAw==" length="6033404" type="application/octet-stream" />
+</item>
+<item>
   <title>Lokalite 2.3.0</title>
   <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.3.0</link>
   <sparkle:version>2.3.0</sparkle:version>


### PR DESCRIPTION
Update Homebrew formula and cask to v2.4.0.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite-app.rb`
- `appcast.xml` (Sparkle in-app update feed)

The branch was created automatically from the release tag and is ready to merge into `main`.
