### PR TITLE
Update Homebrew formula, cask, and Sparkle appcast to v2.4.1

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.4.0"
-  sha256 "238f22a543f6c932c502eea41ce370daa26a1cddd00863446782d7e23fdce6b9"
+  version "2.4.1"
+  sha256 "44cad1b7c6df5ec1cde1b94305396e53b487fb12b8f24ace48ef8259d7ea1457"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.4.0.tar.gz"
-  sha256 "843c11401412ff55f34fc1efc4306a2685d2a5fde6c29776dddc4b3dba82acc1"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.4.1.tar.gz"
+  sha256 "c3226923092fb4dbab1aa273bff0f4a954436850da9d1f468db0b00e07d6d52d"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -7,6 +7,15 @@
     <language>en</language>
     <!-- BEGIN ITEMS -->
 <item>
+  <title>Lokalite 2.4.1</title>
+  <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.4.1</link>
+  <sparkle:version>2.4.1</sparkle:version>
+  <sparkle:shortVersionString>2.4.1</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+  <pubDate>Sat, 04 Jul 2026 09:10:36 +0000</pubDate>
+  <enclosure url="https://github.com/RubenGlez/lokalite/releases/download/v2.4.1/Lokalite-v2.4.1.dmg" sparkle:edSignature="y3okcZ8Bewh/Eyh85r2ZhyqrY2D0AZ0sKP2vn4sFJip77uQE4CSRYBJfxPCy1evO+33KLJ6/V8Si9FvZuJQzAA==" length="6944022" type="application/octet-stream" />
+</item>
+<item>
   <title>Lokalite 2.4.0</title>
   <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.4.0</link>
   <sparkle:version>2.4.0</sparkle:version>


### PR DESCRIPTION
Update Homebrew formula and cask to v2.4.1.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite-app.rb`
- `appcast.xml` (Sparkle in-app update feed)

The branch was created automatically from the release tag and is ready to merge into `main`.
