### PR TITLE
Update Homebrew formula, cask, and Sparkle appcast to v2.5.0

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.4.1"
-  sha256 "44cad1b7c6df5ec1cde1b94305396e53b487fb12b8f24ace48ef8259d7ea1457"
+  version "2.5.0"
+  sha256 "990f1c2d07bad824993bb92bbf4e93b5fc99055b82320dbae3381cc68a5a2e21"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.4.1.tar.gz"
-  sha256 "c3226923092fb4dbab1aa273bff0f4a954436850da9d1f468db0b00e07d6d52d"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.5.0.tar.gz"
+  sha256 "c88130ebe027aabaf0eff08684576ab2643922048f7b645c52a7460250821711"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -7,6 +7,15 @@
     <language>en</language>
     <!-- BEGIN ITEMS -->
 <item>
+  <title>Lokalite 2.5.0</title>
+  <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.5.0</link>
+  <sparkle:version>2.5.0</sparkle:version>
+  <sparkle:shortVersionString>2.5.0</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+  <pubDate>Wed, 08 Jul 2026 14:49:13 +0000</pubDate>
+  <enclosure url="https://github.com/RubenGlez/lokalite/releases/download/v2.5.0/Lokalite-v2.5.0.dmg" sparkle:edSignature="ObnjuYxtb0BjprcCGT2SmTbT68kA4es+5uVjZu1ZyIJ1zAT7K2POzfnSFLUI532lCeBESri5VK5TtEYnCVx4CQ==" length="6013239" type="application/octet-stream" />
+</item>
+<item>
   <title>Lokalite 2.4.1</title>
   <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.4.1</link>
   <sparkle:version>2.4.1</sparkle:version>


### PR DESCRIPTION
Update Homebrew formula and cask to v2.5.0.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite-app.rb`
- `appcast.xml` (Sparkle in-app update feed)

The branch was created automatically from the release tag and is ready to merge into `main`.
