### PR TITLE
Update Homebrew formula, cask, and Sparkle appcast to v2.5.1

### DIFF
--- a/Casks/lokalite-app.rb
+++ b/Casks/lokalite-app.rb
@@ -1,6 +1,6 @@
 cask "lokalite-app" do
-  version "2.5.0"
-  sha256 "990f1c2d07bad824993bb92bbf4e93b5fc99055b82320dbae3381cc68a5a2e21"
+  version "2.5.1"
+  sha256 "49cf8e95c74382b4c80191ce2fa76942802e79358207b526ac2127f881fdd169"
 
   url "https://github.com/RubenGlez/lokalite/releases/download/v#{version}/Lokalite-v#{version}.dmg"
   name "Lokalite"

--- a/Formula/lokalite.rb
+++ b/Formula/lokalite.rb
@@ -1,8 +1,8 @@
 class Lokalite < Formula
   desc "Local-first secrets manager for developers — vault, CLI, and MCP server"
   homepage "https://github.com/RubenGlez/lokalite"
-  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.5.0.tar.gz"
-  sha256 "c88130ebe027aabaf0eff08684576ab2643922048f7b645c52a7460250821711"
+  url "https://github.com/RubenGlez/lokalite/archive/refs/tags/v2.5.1.tar.gz"
+  sha256 "26d6f1de1a3af785e6c8093f8ea36d28f3f4f82f46f56ce43b7e8cfc1a4aab51"
   license "MIT"
   head "https://github.com/RubenGlez/lokalite.git", branch: "main"
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -7,6 +7,15 @@
     <language>en</language>
     <!-- BEGIN ITEMS -->
 <item>
+  <title>Lokalite 2.5.1</title>
+  <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.5.1</link>
+  <sparkle:version>2.5.1</sparkle:version>
+  <sparkle:shortVersionString>2.5.1</sparkle:shortVersionString>
+  <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+  <pubDate>Wed, 08 Jul 2026 20:29:59 +0000</pubDate>
+  <enclosure url="https://github.com/RubenGlez/lokalite/releases/download/v2.5.1/Lokalite-v2.5.1.dmg" sparkle:edSignature="JOmf/8whIYL79n8W2s6VwipmJztGf67hZnDWILWbyijk3m7W7S0Th09Lp1Zfm/5Ka1AzuhJbCz1rU41LjoovAw==" length="6944353" type="application/octet-stream" />
+</item>
+<item>
   <title>Lokalite 2.5.0</title>
   <link>https://github.com/RubenGlez/lokalite/releases/tag/v2.5.0</link>
   <sparkle:version>2.5.0</sparkle:version>


### PR DESCRIPTION
Update Homebrew formula and cask to v2.5.1.

This release workflow refreshes:
- `Formula/lokalite.rb`
- `Casks/lokalite-app.rb`
- `appcast.xml` (Sparkle in-app update feed)

The branch was created automatically from the release tag and is ready to merge into `main`.
